### PR TITLE
Suggest to hide the cryptography reading group

### DIFF
--- a/index.html
+++ b/index.html
@@ -405,9 +405,6 @@
 						<a href="https://groups.google.com/a/lists.berkeley.edu/forum/#!forum/secreadgroup">Security Reading Group</a>
 					</li>
 					<li>
-						<a href="https://crypto.eecs.berkeley.edu/reading-group.html">Cryptography Reading Group</a>
-					</li>
-					<li>
 						<a href="https://cltc.berkeley.edu/cltc-spring-2018-seminar-series/">The CLTC's seminar series</a>
 					</li>
 				</ul>


### PR DESCRIPTION
The cryptography reading group no longer works. (better hidden until it recovers)