### PR TITLE
Update the website (2021)

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@
 								John Bethencourt
 							</li>
 							<li>
-								<a href="https://www.hatswitch.org/~nikita/">Nikita Borisov</a>
+								<a href="http://hatswitch.org/nikita">Nikita Borisov</a>
 							</li>
 							<li>
 								<a href="https://nicholas.carlini.com/">Nicholas Carlini</a>
@@ -191,16 +191,16 @@
 								<a href="https://ckev.in/j/about/">Kevin Chen</a>
 							</li>
 							<li>
-								Monica Chew
+								<a href="https://www.linkedin.com/in/monicachew/">Monica Chew</a>
 							</li>
 							<li>
-								Erika Chin
+								<a href="https://www.linkedin.com/in/erikachin/">Erika Chin</a>
 							</li>
 							<li>
-								Chia Yuan Cho
+								<a href="https://www.linkedin.com/in/chiayuan-cho/">Chia Yuan Cho</a>
 							</li>
 							<li>
-								<a href="http://www.arelcordero.com/">Arel Cordero</a>
+								<a href="https://www.linkedin.com/in/arel-cordero-361502/">Arel Cordero</a>
 							</li>
 							<li>
 								<a href="https://www.microsoft.com/en-us/research/people/wdcui/">Weidong Cui</a>
@@ -209,7 +209,7 @@
 								<a href="https://people.csail.mit.edu/thurston/">Thurston Dang</a>
 							</li>
 							<li>
-								Rachna Dhamija
+								<a href="https://www.linkedin.com/in/dhamija/"Rachna Dhamija</a>
 							</li>
 							<li>
 								<a href="https://www.adrienneporterfelt.com/">Adrienne Porter Felt</a>
@@ -222,7 +222,7 @@
 								<a href="https://cs.uwaterloo.ca/~iang/">Ian Goldberg</a>
 							</li>
 							<li>
-								<a href="http://home.engineering.iastate.edu/~neilgong/">Neil Gong</a>
+								<a href="https://people.duke.edu/~zg70/">Neil Gong</a>
 							</li>
 							<li>
 								Warren He

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
 							<br>&amp; stellar staff</h4>
 						<ul>
 							<li>
-								<a href="http://idemertzis.com/">Ioannis (Yannis) Demertzis</a>
+								<a href="https://idemertzis.com/">Ioannis (Yannis) Demertzis</a>
 							</li>
 							<li>
                                                                 <a href="https://kornaropoulos.webflow.io/">Evgenios Kornaropoulos</a>
@@ -110,7 +110,7 @@
 						<!-- Please keep entries alphabetical by last name. -->
 						<ul>
 							<li>
-								Noura Alomar
+								<a href="https://fac.ksu.edu.sa/nnalomar">Noura Alomar</a>
 							</li>
 							<li>
 								<a href="https://ecawthon.github.io/">Eleanor Cawthon</a>
@@ -143,16 +143,13 @@
 								<a href="https://people.eecs.berkeley.edu/~pratyushmishra">Pratyush Mishra</a>
 							</li>
 							<li>
-								<a href="https://rishabhpoddar.com/">Rishabh Poddar</a>
-							</li>
-							<li>
 								<a href="https://nikitasamarin.com/">Nikita Samarin</a>
 							</li>
 							<li>
 								<a href="https://www.ericswallace.com/">Eric Wallace</a>
 							</li>
 							<li>
-								<a href="https://spartazhihu.github.io/">Lun Wang</a>
+								<a href="https://wanglun1996.github.io/">Lun Wang</a>
 							</li>
 							<li>
 								Jean-Luc Watson
@@ -161,7 +158,7 @@
 								<a href="https://niconiconi.github.io/">Tiancheng Xie</a>
 							</li>
 							<li>
-								Jiaheng Zhang	
+								<a href="https://zjhzjh123.github.io/">Jiaheng Zhang</a>
 							</li>
 						</ul>
 
@@ -285,6 +282,9 @@
 							<li>
 								<a href="https://netsec.ethz.ch/people/aperrig/">Adrian Perrig</a>
 							</li>
+							<li>
+                                                                <a href="https://rishabhpoddar.com/">Rishabh Poddar</a>
+                                                        </li>
 							<li>
 								<a href="https://www.linkedin.com/in/rebecca-portnoff-3b784039">Rebecca Portnoff</a>
 							</li>

--- a/index.html
+++ b/index.html
@@ -50,37 +50,24 @@
 						<h4>Formidable faculty</h4>
 						<ul>
 							<li>
-
 								<a href="https://people.eecs.berkeley.edu/~alexch">Alessandro Chiesa</a>
-
 							</li>
 							<li>
-
+								<a href="https://nacrooks.github.io/">Natacha Crooks</a>
+							</li>
+							<li>
 								<a href="https://people.eecs.berkeley.edu/~adj">Anthony Joseph</a>
-
 							</li>
 							<li>
-
 								<a href="https://www.icir.org/vern/">Vern Paxson</a>
-
 							</li>
 							<li>
-
 								<a href="https://people.eecs.berkeley.edu/~raluca/">Raluca Ada Popa</a>
-
 							</li>
 							<li>
-
 								<a href="https://people.eecs.berkeley.edu/~dawnsong/">Dawn Song</a>
-
 							</li>
 							<li>
-
-								<a href="https://people.eecs.berkeley.edu/~tygar/">Doug Tygar</a>
-
-							</li>
-							<li>
-
 								<a href="https://people.eecs.berkeley.edu/~daw/">David Wagner</a>
 							</li>
 						</ul>
@@ -101,14 +88,18 @@
 							<br>&amp; stellar staff</h4>
 						<ul>
 							<li>
-								<a href="https://www.linkedin.com/in/alisafrik">Alisa Frik</a>
+								<a href="http://idemertzis.com/">Ioannis (Yannis) Demertzis</a>
 							</li>
 							<li>
-								<a href="https://people.eecs.berkeley.edu/~dkohlbre/">David Kohlbrenner</a>
+                                                                <a href="https://kornaropoulos.webflow.io/">Evgenios Kornaropoulos</a>
+                                                        </li>
+							<li>
+								<a href="https://www.di.ens.fr/~orru/">Michele Orrù</a>
+							<li>
+								Katerina Sotiraki
 							</li>
 							<li>
-								<a href="https://kornaropoulos.webflow.io/">Evgenios
-									Kornaropoulos</a>
+								<a href="https://snwagh.github.io/">Sameer Wagh</a>
 							</li>
 							<li>
 								<a href="https://ece.ubc.ca/~primal/">Primal Wijesekera</a>
@@ -143,19 +134,10 @@
 								<a href="https://people.eecs.berkeley.edu/~hendrycks/">Dan Hendrycks</a>
 							</li>
 							<li>
-								<a href="https://people.eecs.berkeley.edu/~grantho/">Grant Ho</a>
-							</li>
-							<li>
-								Yuncong Hu
-							</li>
-							<li>
-								Sukrit Kalra
+								<a href="https://huyuncong.com/">Yuncong Hu</a>
 							</li>
 							<li>
 								<a href="https://www.nathanmalkin.com/">Nathan Malkin</a>
-							</li>
-							<li>
-								<a href="https://people.eecs.berkeley.edu/~mmccoyd/">Michael McCoyd</a>
 							</li>
 							<li>
 								<a href="https://people.eecs.berkeley.edu/~pratyushmishra">Pratyush Mishra</a>
@@ -165,12 +147,6 @@
 							</li>
 							<li>
 								<a href="https://nikitasamarin.com/">Nikita Samarin</a>
-							</li>
-							<li>
-								<a href="https://people.eecs.berkeley.edu/~ricshin/">Richard Shin</a>
-							</li>
-							<li>
-								<a href="https://people.eecs.berkeley.edu/~json/">Jeongseok Son</a>
 							</li>
 							<li>
 								<a href="https://www.ericswallace.com/">Eric Wallace</a>
@@ -186,9 +162,6 @@
 							</li>
 							<li>
 								Jiaheng Zhang	
-							</li>
-							<li>
-								<a href="https://people.eecs.berkeley.edu/~wzheng/">Wenting Zheng</a>
 							</li>
 						</ul>
 
@@ -257,6 +230,9 @@
 							<li>
 								Warren He
 							</li>
+							<li>
+                                                                <a href="https://cseweb.ucsd.edu/~grho/">Grant Ho</a>
+                                                        </li>
 							<li>Sakshi Jain</li>
 							<li>
 								<a href="http://www.vividmachines.com/">Steve Hanna</a>
@@ -277,11 +253,14 @@
 								<a href="http://www.chriskarlof.com/">Chris Karlof</a>
 							</li>
 							<li>
-								<a href="https://people.eecs.berkeley.edu/~frankli/">Frank Li</a>
+								<a href="https://frankli.ece.gatech.edu/">Frank Li</a>
 							</li>
 							<li>
 								<a href="https://billmarczak.org/">Bill Marczak</a>
 							</li>
+							<li>
+                                                                Michael McCoyd
+                                                        </li>
 							<li>
 								<a href="https://dblp.uni-trier.de/pers/hd/m/Mettler:Adrian.html">Adrian Mettler</a>
 							</li>
@@ -323,6 +302,12 @@
 								<a href="https://umeshshankar.com/">Umesh Shankar</a>
 							</li>
 							<li>
+                                                                <a href="https://rshin.github.io/">Richard Shin</a>
+                                                        </li>
+							<li>
+                                                                <a href="https://people.eecs.berkeley.edu/~json/">Jeongseok Son</a>
+                                                        </li>
+							<li>
 								<a href="https://www.eecs.berkeley.edu/~dawnsong/">Dawn Song</a>
 							</li>
 							<li>
@@ -353,6 +338,10 @@
 							<li>
 								<a href="http://zesty.ca/">Ka-Ping Yee</a>
 							</li>
+
+							<li>
+                                                                <a href="https://people.eecs.berkeley.edu/~wzheng/">Wenting Zheng</a>
+                                                        </li>
 
 							<!-- Postdocs and reseachers -->
 

--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
 								<a href="https://wanglun1996.github.io/">Lun Wang</a>
 							</li>
 							<li>
-								Jean-Luc Watson
+								<a href="https://www.linkedin.com/in/jeanlucwatson/">Jean-Luc Watson</a>
 							</li>
 							<li>
 								<a href="https://niconiconi.github.io/">Tiancheng Xie</a>
@@ -214,7 +214,9 @@
 							<li>
 								<a href="https://www.adrienneporterfelt.com/">Adrienne Porter Felt</a>
 							</li>
-							<li>David Fifield</li>
+							<li>
+								<a href="https://www.bamsoftware.com/david/">David Fifield</a>
+							</li>
 							<li>
 								<a href="https://mfinifter.github.io/">Matthew Finifter</a>
 							</li>
@@ -225,29 +227,31 @@
 								<a href="https://people.duke.edu/~zg70/">Neil Gong</a>
 							</li>
 							<li>
-								Warren He
+								<a href="https://www.linkedin.com/in/warrenh/">Warren He</a>
 							</li>
 							<li>
                                                                 <a href="https://cseweb.ucsd.edu/~grho/">Grant Ho</a>
                                                         </li>
-							<li>Sakshi Jain</li>
 							<li>
-								<a href="http://www.vividmachines.com/">Steve Hanna</a>
+								<a href="https://www.linkedin.com/in/sakshirjain/">Sakshi Jain</a>
+							</li>
+							<li>
+								<a href="https://www.vividmachines.com/">Steve Hanna</a>
 							</li>
 							<li>
 								<a href="https://www1.icsi.berkeley.edu/~mobinjav/">Mobin Javed</a>
 							</li>
 							<li>
-								Noah Johnson
+								<a href="https://www.linkedin.com/in/noah-johnson-914262198/">Noah Johnson</a>
 							</li>
 							<li>
 								<a href="https://www.cs.sunysb.edu/~rob/">Rob Johnson</a>
 							</li>
 							<li>
-								Alex Kantchelian
+								<a href="https://www.linkedin.com/in/alex-kantchelian-4b713011/">Alex Kantchelian</a>
 							</li>
 							<li>
-								<a href="http://www.chriskarlof.com/">Chris Karlof</a>
+								<a href="https://www.linkedin.com/in/karlof/">Chris Karlof</a>
 							</li>
 							<li>
 								<a href="https://frankli.ece.gatech.edu/">Frank Li</a>
@@ -256,13 +260,13 @@
 								<a href="https://billmarczak.org/">Bill Marczak</a>
 							</li>
 							<li>
-                                                                Michael McCoyd
+                                                                <a href="https://www.linkedin.com/in/michael-mccoyd/">Michael McCoyd</a>
                                                         </li>
 							<li>
-								<a href="https://dblp.uni-trier.de/pers/hd/m/Mettler:Adrian.html">Adrian Mettler</a>
+								<a href="https://www.linkedin.com/in/adrian-mettler-204304138/">Adrian Mettler</a>
 							</li>
 							<li>
-								<a href="http://bradmiller.io/">Brad Miller</a>
+								<a href="https://www.linkedin.com/in/brad-miller-79a8398/">Brad Miller</a>
 							</li>
 							<li>
 								<a href="https://mitar.tnode.com/">Mitar Milutinovic</a>
@@ -274,10 +278,10 @@
 								<a href="https://austinmurdock.com/">Austin Murdock</a>
 							</li>
 							<li>
-								Blaine Nelson
+								<a href="https://www.linkedin.com/in/blaine-nelson-06310992/">Blaine Nelson</a>
 							</li>
 							<li>
-								<a href="https://people.eecs.berkeley.edu/~pearce/">Paul Pearce</a>
+								<a href="https://www.cc.gatech.edu/~pearce/">Paul Pearce</a>
 							</li>
 							<li>
 								<a href="https://netsec.ethz.ch/people/aperrig/">Adrian Perrig</a>
@@ -286,18 +290,20 @@
                                                                 <a href="https://rishabhpoddar.com/">Rishabh Poddar</a>
                                                         </li>
 							<li>
-								<a href="https://www.linkedin.com/in/rebecca-portnoff-3b784039">Rebecca Portnoff</a>
+								<a href="https://www.linkedin.com/in/dr-rebecca-portnoff-3b784039/">Rebecca Portnoff</a>
 							</li>
 							<li>
 								<a href="https://justinsamuel.com/">Justin Samuel</a>
 							</li>
 							<li>
-								<a href="http://naveen.ksastry.com/">Naveen Sastry</a>
+								<a href="https://www.linkedin.com/in/naveen-sastry-13831524/">Naveen Sastry</a>
 							</li>
 							<li>
 								<a href="https://www.comp.nus.edu.sg/~prateeks/">Prateek Saxena</a>
 							</li>
-							<li>Ben Schwarz</li>
+							<li>
+								<a href="https://www.linkedin.com/in/benjamin-schwarz-6380b2b2/">Ben Schwarz</a>
+							</li>
 							<li>
 								<a href="https://umeshshankar.com/">Umesh Shankar</a>
 							</li>
@@ -317,7 +323,7 @@
 								<a href="https://cs.unc.edu/~csturton/">Cynthia Sturton</a>
 							</li>
 							<li>
-								<a href="http://www.inwyrd.com/">Kurt Thomas</a>
+								<a href="https://www.inwyrd.com/">Kurt Thomas</a>
 							</li>
 							<li>
 								<a href="https://notyetsecure.com/">Chris Thompson</a>
@@ -325,7 +331,9 @@
 							<li>
 								<a href="https://matthias.vallentin.net/">Matthias Vallentin</a>
 							</li>
-							<li>Jason Waddle</li>
+							<li>
+								<a href="https://www.linkedin.com/in/jason-waddle-3157b145/">Jason Waddle</a>
+							</li>
 							<li>
 								<a href="https://www.eecs.berkeley.edu/~daw/">David Wagner</a>
 							</li>
@@ -333,7 +341,7 @@
 								<a href="https://www.joelweinberger.us/">Joel Weinberger</a>
 							</li>
 							<li>
-								Alma Whitten
+								<a href="https://www.linkedin.com/in/alma-whitten-28997711/">Alma Whitten</a>
 							</li>
 							<li>
 								<a href="http://zesty.ca/">Ka-Ping Yee</a>
@@ -451,7 +459,9 @@
 					<li>CS 161:
 						<strong>Computer Security</strong>
 						-
-						<a class="current" href="https://www.cs161.org/">s20</a>,
+						<a class="current" href="https://inst.eecs.berkeley.edu/~cs161/sp21/">s21</a>,
+						<a href="https://inst.eecs.berkeley.edu/~cs161/fa20/">f20</a>,
+						<a href="https://www.cs161.org/">s20</a>,
 						<a href="https://inst.eecs.berkeley.edu/~cs161/fa19">f19</a>,
 						<a href="https://inst.eecs.berkeley.edu/~cs161/sp19/">s19</a>,
 						<a href="https://inst.eecs.berkeley.edu/~cs161/fa18/">f18</a>,
@@ -469,9 +479,10 @@
 						<a href="https://inst.eecs.berkeley.edu/~cs161/fa05/">f05</a>
 					</li>
 					<li>
-						CS 194-034:
+						CS 171:
 						<strong>Undergraduate Cryptography</strong>
 						-
+						<a class="current" href="https://people.eecs.berkeley.edu/~sanjamg/teaching/cs171-spring21">s21</a>,
 						<a href="https://www2.eecs.berkeley.edu/Courses/CS194_3379/">f19</a>,
 						<a href="https://people.eecs.berkeley.edu/~sanjamg/classes/cs194-spring19/">s19</a>
 					</li>
@@ -487,6 +498,7 @@
 					<li>CS 261:
 						<strong>Computer Security</strong>
 						-
+						<a class="current" href="https://people.eecs.berkeley.edu/~daw/teaching/cs261-s21/">s21</a>,
 						<a href="https://inst.eecs.berkeley.edu/~cs261/fa18/">f18</a>,
 						<a href="https://inst.eecs.berkeley.edu/~cs261/fa17/">f17</a>,
 						<a href="https://eecs.berkeley.edu/~raluca/cs261-f15/">f15</a>,
@@ -504,7 +516,7 @@
 					<li>CS 261N:
 						<strong>Internet/Network Security</strong>
 						-
-						<a class="current" href="https://www.icir.org/vern/cs261n/">s20</a>,
+						<a href="https://www.icir.org/vern/cs261n/">s20</a>,
 						<a href="https://www.icir.org/vern/cs261n-Fa16/">f16</a>,
 						<a href="https://www.icir.org/vern/cs261n-Sp15/">s15</a>,
 						<a href="https://www.icir.org/vern/cs261n-Sp14/">s14</a>,
@@ -518,6 +530,7 @@
 					<li>CS 276:
 						<strong>Cryptography</strong>
 						-
+						<a href="https://inst.eecs.berkeley.edu/~cs276/fa20/">f20</a>,
 						<a href="https://people.eecs.berkeley.edu/~sanjamg/classes/cs276-fall18/">f18</a>, 
 						<a href="https://people.eecs.berkeley.edu/~alexch/classes/CS276-F2017.html">f17</a>,
 						<a href="https://people.eecs.berkeley.edu/~sanjamg/classes/cs276-fall16/">f16</a>,
@@ -553,8 +566,8 @@
 					<li>CS 294:
 						<strong>Advanced Cryptography</strong>
 						-
-						<a href="https://www2.eecs.berkeley.edu/Courses/CS294_2964/">s20</a>
-						<a href="https://people.eecs.berkeley.edu/~sanjamg/classes/cs294-spring18/">f18</a>
+						<a href="https://www2.eecs.berkeley.edu/Courses/CS294_2964/">s20</a>,
+						<a href="https://people.eecs.berkeley.edu/~sanjamg/classes/cs294-spring18/">f18</a>,
 						<a href="https://people.eecs.berkeley.edu/~sanjamg/classes/cs294-spring18/">s18</a>
 					</li>
 					<li>CS 294:
@@ -590,7 +603,7 @@
 					<li>CS 294:
 						<strong>Lattices, Learning with Errors and Post-Quantum Cryptography</strong>
 						-
-						<a class="current" href="https://www2.eecs.berkeley.edu/Courses/CS294_4130/">s20</a>
+						<a href="https://www2.eecs.berkeley.edu/Courses/CS294_4130/">s20</a>
 					</li>
 					<li>INFO 290-001
 						<strong>Cybersecurity in Context</strong>
@@ -620,7 +633,7 @@
 
 	<footer class="footer">
 		<div class="text-center container">
-			Last updated spring 2020. If something looks wrong,
+			Last updated spring 2021. If something looks wrong,
 			<a href="https://github.com/nmalkin/secweb">please help us fix it</a>!
 		</div>
 	</footer>

--- a/index.html
+++ b/index.html
@@ -140,13 +140,22 @@
 								<a href="https://huyuncong.com/">Yuncong Hu</a>
 							</li>
 							<li>
+								<a href="https://www.linkedin.com/in/an-ju-phd/">An Ju</a>
+							</li>
+							<li>
 								<a href="https://www.nathanmalkin.com/">Nathan Malkin</a>
 							</li>
 							<li>
 								<a href="https://people.eecs.berkeley.edu/~pratyushmishra">Pratyush Mishra</a>
 							</li>
 							<li>
+								<a href="https://normanmu.com/">Norman Mu</a>
+							</li>
+							<li>
 								<a href="https://nikitasamarin.com/">Nikita Samarin</a>
+							</li>
+							<li>
+								<a href="https://chawins.github.io/">Chawin Sitawarin</a>
 							</li>
 							<li>
 								<a href="https://www.ericswallace.com/">Eric Wallace</a>

--- a/index.html
+++ b/index.html
@@ -91,8 +91,11 @@
 								<a href="https://idemertzis.com/">Ioannis (Yannis) Demertzis</a>
 							</li>
 							<li>
-                                                                <a href="https://kornaropoulos.webflow.io/">Evgenios Kornaropoulos</a>
-                                                        </li>
+								<a href="https://www1.icsi.berkeley.edu/~afrik/">Alisa Frik</a>
+							</li>
+							<li>
+								<a href="https://kornaropoulos.webflow.io/">Evgenios Kornaropoulos</a>
+							</li>
 							<li>
 								<a href="https://www.di.ens.fr/~orru/">Michele Orrù</a>
 							<li>
@@ -110,7 +113,7 @@
 						<!-- Please keep entries alphabetical by last name. -->
 						<ul>
 							<li>
-								<a href="https://fac.ksu.edu.sa/nnalomar">Noura Alomar</a>
+								<a href="https://blues.cs.berkeley.edu/people/noura_alomar/">Noura Alomar</a>
 							</li>
 							<li>
 								<a href="https://ecawthon.github.io/">Eleanor Cawthon</a>
@@ -230,8 +233,8 @@
 								<a href="https://www.linkedin.com/in/warrenh/">Warren He</a>
 							</li>
 							<li>
-                                                                <a href="https://cseweb.ucsd.edu/~grho/">Grant Ho</a>
-                                                        </li>
+								<a href="https://cseweb.ucsd.edu/~grho/">Grant Ho</a>
+							</li>
 							<li>
 								<a href="https://www.linkedin.com/in/sakshirjain/">Sakshi Jain</a>
 							</li>
@@ -260,8 +263,8 @@
 								<a href="https://billmarczak.org/">Bill Marczak</a>
 							</li>
 							<li>
-                                                                <a href="https://www.linkedin.com/in/michael-mccoyd/">Michael McCoyd</a>
-                                                        </li>
+								<a href="https://www.linkedin.com/in/michael-mccoyd/">Michael McCoyd</a>
+							</li>
 							<li>
 								<a href="https://www.linkedin.com/in/adrian-mettler-204304138/">Adrian Mettler</a>
 							</li>
@@ -287,8 +290,8 @@
 								<a href="https://netsec.ethz.ch/people/aperrig/">Adrian Perrig</a>
 							</li>
 							<li>
-                                                                <a href="https://rishabhpoddar.com/">Rishabh Poddar</a>
-                                                        </li>
+								<a href="https://rishabhpoddar.com/">Rishabh Poddar</a>
+							</li>
 							<li>
 								<a href="https://www.linkedin.com/in/dr-rebecca-portnoff-3b784039/">Rebecca Portnoff</a>
 							</li>
@@ -308,11 +311,11 @@
 								<a href="https://umeshshankar.com/">Umesh Shankar</a>
 							</li>
 							<li>
-                                                                <a href="https://rshin.github.io/">Richard Shin</a>
-                                                        </li>
+								<a href="https://rshin.github.io/">Richard Shin</a>
+							</li>
 							<li>
-                                                                <a href="https://people.eecs.berkeley.edu/~json/">Jeongseok Son</a>
-                                                        </li>
+								<a href="http://jeongseok.net/">Jeongseok Son</a>
+							</li>
 							<li>
 								<a href="https://www.eecs.berkeley.edu/~dawnsong/">Dawn Song</a>
 							</li>
@@ -346,10 +349,9 @@
 							<li>
 								<a href="http://zesty.ca/">Ka-Ping Yee</a>
 							</li>
-
 							<li>
-                                                                <a href="https://people.eecs.berkeley.edu/~wzheng/">Wenting Zheng</a>
-                                                        </li>
+								<a href="https://people.eecs.berkeley.edu/~wzheng/">Wenting Zheng</a>
+							</li>
 
 							<!-- Postdocs and reseachers -->
 
@@ -461,7 +463,7 @@
 						-
 						<a class="current" href="https://inst.eecs.berkeley.edu/~cs161/sp21/">s21</a>,
 						<a href="https://inst.eecs.berkeley.edu/~cs161/fa20/">f20</a>,
-						<a href="https://www.cs161.org/">s20</a>,
+						<a href="https://inst.eecs.berkeley.edu/~cs161/sp20/">s20</a>,
 						<a href="https://inst.eecs.berkeley.edu/~cs161/fa19">f19</a>,
 						<a href="https://inst.eecs.berkeley.edu/~cs161/sp19/">s19</a>,
 						<a href="https://inst.eecs.berkeley.edu/~cs161/fa18/">f18</a>,
@@ -531,7 +533,7 @@
 						<strong>Cryptography</strong>
 						-
 						<a href="https://inst.eecs.berkeley.edu/~cs276/fa20/">f20</a>,
-						<a href="https://people.eecs.berkeley.edu/~sanjamg/classes/cs276-fall18/">f18</a>, 
+						<a href="https://people.eecs.berkeley.edu/~sanjamg/classes/cs276-fall18/">f18</a>,
 						<a href="https://people.eecs.berkeley.edu/~alexch/classes/CS276-F2017.html">f17</a>,
 						<a href="https://people.eecs.berkeley.edu/~sanjamg/classes/cs276-fall16/">f16</a>,
 						<a href="https://www.eecs.berkeley.edu/~alexch/classes/CS276-F2015.html">f15</a>,

--- a/index.html
+++ b/index.html
@@ -209,7 +209,7 @@
 								<a href="https://people.csail.mit.edu/thurston/">Thurston Dang</a>
 							</li>
 							<li>
-								<a href="https://www.linkedin.com/in/dhamija/"Rachna Dhamija</a>
+								<a href="https://www.linkedin.com/in/dhamija/">Rachna Dhamija</a>
 							</li>
 							<li>
 								<a href="https://www.adrienneporterfelt.com/">Adrienne Porter Felt</a>


### PR DESCRIPTION
This is a draft PR. Feedback and info would be useful.

What has been done:
- Add Natacha Crooks into a faculty on security
- Say goodbye to Prof. Tygar.
- Update the list of postdocs
- Update the list of students
- Update certain website links

Yet, a detailed pass might be needed, and I have strong feelings that we are still missing some people (e.g., master students?). And a number of links are in `people.eecs.berkeley.edu` which would expire soon. Also, Rishabh is graduating soon.  

Also, new courses need to be added. 